### PR TITLE
Added invalidate method to be able to mark a job cache as invalid without deleting it completely

### DIFF
--- a/cacheback/base.py
+++ b/cacheback/base.py
@@ -120,6 +120,20 @@ class Job(object):
                 "Unable to save data of type %s to Memcache" % (
                     type(data)))
 
+    def invalidate(self, *raw_args, **raw_kwargs):
+        """
+        Mark the cache as invalid and trigger an asynchronous
+        job to refresh the cache
+        """
+        args = self.prepare_args(*raw_args)
+        kwargs = self.prepare_kwargs(**raw_kwargs)
+        key = self.key(*args, **kwargs)
+        item = cache.get(key)
+        if item is not None:
+            expiry, data = item
+            self.cache_set(key, self.timeout(*args, **kwargs), data)
+            self.async_refresh(*args, **kwargs)
+
     def refresh(self, *args, **kwargs):
         """
         Fetch the result SYNCHRONOUSLY and populate the cache


### PR DESCRIPTION
We had a case in which we wanted to invalidate the cache value of a job when a related object is saved, using the post_save signal. I wasn't sure if I could 
