### PR TITLE
Allows django-cacheback to work with DummyCache for development

### DIFF
--- a/cacheback/base.py
+++ b/cacheback/base.py
@@ -2,6 +2,7 @@ import time
 import logging
 
 from django.core.cache import cache
+from django.core.cache.backends.dummy import DummyCache
 
 from cacheback import tasks
 
@@ -138,7 +139,8 @@ class Job(object):
         # will fail silently.  It's tricky to test for this behaviour as cached
         # QuerySets aren't "equal" to the original.
         __, cached_data = cache.get(key, (None, None))
-        if data is not None and cached_data is None:
+        if data is not None and cached_data is None and \
+            not isinstance(cache, DummyCache):
             raise RuntimeError(
                 "Unable to save data of type %s to cache" % (
                     type(data)))

--- a/tests/job_tests.py
+++ b/tests/job_tests.py
@@ -1,5 +1,8 @@
 from django.test import TestCase
+import cacheback.base
+from django.core.cache.backends.dummy import DummyCache
 from django.core.cache import cache
+
 
 from cacheback.base import Job
 
@@ -79,3 +82,18 @@ class TestNonIterableCacheItem(TestCase):
     def test_returns_correct_result(self):
         self.assertIsNone(self.job.get(None))
         self.assertEqual(1, self.job.get(None))
+
+
+class DummyCacheTest(TestCase):
+
+    def setUp(self):
+        self.cache = cache
+        cacheback.base.cache = DummyCache('unique-snowflake', {})
+        self.job = SingleArgJob()
+
+    def tearDown(self):
+        cacheback.base.cache  = self.cache
+    
+    def test_dummy_cache_does_not_raise_error(self):
+        self.assertEqual('ALAN', self.job.get('alan'))
+        self.assertEqual('BARRY', self.job.get('barry'))


### PR DESCRIPTION
The code that checks whether the value was correctly stored was raising "Unable to save data of type %s to cache" exceptions when I used DummyCache for local testing (which doesn't store any value), so I adjusted it to test for DummyCache.
