### PR TITLE
Fix for 'No handlers could be found for logger "cacheback"' errors in web server logs

### DIFF
--- a/cacheback/base.py
+++ b/cacheback/base.py
@@ -5,6 +5,7 @@ from django.core.cache import cache
 
 from cacheback import tasks
 
+logging.basicConfig()
 logger = logging.getLogger('cacheback')
 
 MEMCACHE_MAX_EXPIRATION = 2592000


### PR DESCRIPTION
This prevents 'No handlers could be found for logger "cacheback"' errors in web server logs (tested with Apache).
