### PR TITLE
python puppet module url + mock in reqs

### DIFF
--- a/makefile
+++ b/makefile
@@ -6,7 +6,7 @@ puppet:
 	# Install puppet modules required to set-up sandbox server
 	puppet module install --target-dir sandbox/puppet/modules/ puppetlabs-rabbitmq -v 2.0.1
 	puppet module install --target-dir sandbox/puppet/modules/ saz-memcached -v 2.0.2
-	git clone git://github.com/uggedal/puppet-module-python.git sandbox/puppet/modules/python
+	git clone git://github.com/puppetmodules/puppet-module-python.git sandbox/puppet/modules/python
 	git clone git://github.com/codeinthehole/puppet-userconfig.git sandbox/puppet/modules/userconfig
 
 release:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ django-nose==1.1
 nose==1.1.2
 django-debug-toolbar==0.9.4
 pinocchio==0.3.1
+mock==1.0.1


### PR DESCRIPTION
Fixed the url to the python puppet module (it seems to be wrong in their own README actually).
Added mock to requirements.txt
