### PR TITLE
Allow overriding options for refresh_cache.apply_async.

### DIFF
--- a/cacheback/decorators.py
+++ b/cacheback/decorators.py
@@ -5,7 +5,8 @@ from django.utils.decorators import available_attrs
 from cacheback.function import FunctionJob
 
 
-def cacheback(lifetime=None, fetch_on_miss=None, job_class=None):
+def cacheback(lifetime=None, fetch_on_miss=None, job_class=None,
+              task_options=None):
     """
     Decorate function to cache its return value.
 
@@ -17,7 +18,8 @@ def cacheback(lifetime=None, fetch_on_miss=None, job_class=None):
     """
     if job_class is None:
         job_class = FunctionJob
-    job = job_class(lifetime, fetch_on_miss)
+    job = job_class(lifetime=lifetime, fetch_on_miss=fetch_on_miss,
+                    task_options=task_options)
 
     def _wrapper(fn):
         # using available_attrs to work around http://bugs.python.org/issue3445

--- a/cacheback/function.py
+++ b/cacheback/function.py
@@ -8,11 +8,13 @@ class FunctionJob(Job):
     Job for executing a function and caching the result
     """
 
-    def __init__(self, lifetime=None, fetch_on_miss=None):
+    def __init__(self, lifetime=None, fetch_on_miss=None, task_options=None):
         if lifetime is not None:
             self.lifetime = int(lifetime)
         if fetch_on_miss is not None:
             self.fetch_on_miss = fetch_on_miss
+        if task_options is not None:
+            self.task_options = task_options
 
     def prepare_args(self, fn, *args):
         # Convert function into "module:name" form so that is can be pickled and


### PR DESCRIPTION
This change lets you override the celery routing for individual
cacheback-decorated functions.
