### PR TITLE
Always include class_path when generating cache key

### DIFF
--- a/cacheback/base.py
+++ b/cacheback/base.py
@@ -294,11 +294,12 @@ class Job(object):
             return self.class_path
         try:
             if args and not kwargs:
-                return hash(args)
+                return "%s:%s" % (self.class_path, hash(args))
             # The line might break if your passed values are un-hashable.  If
             # it does, you need to override this method and implement your own
             # key algorithm.
-            return "%s:%s:%s" % (hash(args),
+            return "%s:%s:%s:%s" % (self.class_path,
+                                hash(args),
                                 hash(tuple(kwargs.keys())),
                                 hash(tuple(kwargs.values())))
         except TypeError:

--- a/tests/job_tests.py
+++ b/tests/job_tests.py
@@ -51,15 +51,23 @@ class SingleArgJob(Job):
         return name.upper()
 
 
+class AnotherSingleArgJob(Job):
+
+    def fetch(self, name):
+        return '%s!' % name.upper()
+
+
 class TestSingleArgJob(TestCase):
 
     def setUp(self):
         self.job = SingleArgJob()
+        self.another_job = AnotherSingleArgJob()
 
     def tearDown(self):
         cache.clear()
 
     def test_returns_correct_result(self):
+        self.assertEqual('ALAN!', self.another_job.get('alan'))
         self.assertEqual('ALAN', self.job.get('alan'))
         self.assertEqual('BARRY', self.job.get('barry'))
 


### PR DESCRIPTION
class_path is currently not included when generating a key with args/kwargs. Two different jobs called with the same arguments will generate identical keys and return incorrect results.
