### PR TITLE
Remove global logging configuration override

### DIFF
--- a/cacheback/base.py
+++ b/cacheback/base.py
@@ -6,7 +6,6 @@ from django.conf import settings
 
 from cacheback import tasks
 
-logging.basicConfig()
 logger = logging.getLogger('cacheback')
 
 MEMCACHE_MAX_EXPIRATION = 2592000


### PR DESCRIPTION
This reverts commit 2a9a26a0d4b0c6814f584c705ad1bddff186bec7, which added a global logging configuration override. Its result was that in local development (when `DEBUG = True`) the logs would fill up with DEBUG prints from all over the place.

I can't see why this was a logical fix, even for the authors original intent. I propose to remove this.
