### PR TITLE
Add job_class params in @cacheback decorator

### DIFF
--- a/cacheback/decorators.py
+++ b/cacheback/decorators.py
@@ -6,7 +6,7 @@ from cacheback.function import FunctionJob
 
 
 def cacheback(lifetime=None, fetch_on_miss=None, job_class=None,
-              task_options=None):
+              task_options=None, **job_class_kwargs):
     """
     Decorate function to cache its return value.
 
@@ -15,11 +15,13 @@ def cacheback(lifetime=None, fetch_on_miss=None, job_class=None,
                     result is found
     :job_class: The class to use for running the cache refresh job.  Defaults
                 using the FunctionJob.
+    :job_class_kwargs: Any extra kwargs to pass to job_class constructor.
+                       Useful with custom job_class implementations.
     """
     if job_class is None:
         job_class = FunctionJob
     job = job_class(lifetime=lifetime, fetch_on_miss=fetch_on_miss,
-                    task_options=task_options)
+                    task_options=task_options, **job_class_kwargs)
 
     def _wrapper(fn):
         # using available_attrs to work around http://bugs.python.org/issue3445

--- a/tests/decorator_tests.py
+++ b/tests/decorator_tests.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 
 from cacheback.function import FunctionJob
+from cacheback.decorators import cacheback
 
 
 def fetch():
@@ -13,17 +14,16 @@ def fetch_with_args(*args):
 
 class TestDecorator(TestCase):
 
-    def setUp(self):
-        self.job = FunctionJob(fetch_on_miss=False)
-
     def test_wrapping_argless_function(self):
-        self.assertIsNone(self.job.get(fetch))
-        self.assertEqual((1, 2, 3), self.job.get(fetch))
+        decorated_fetch = cacheback(fetch_on_miss=False)(fetch)
+        self.assertIsNone(decorated_fetch())
+        self.assertEqual((1, 2, 3), decorated_fetch())
 
     def test_wrapping_function(self):
-        self.assertIsNone(self.job.get(fetch_with_args, 'testing'))
-        self.assertEqual(('testing',),
-                         self.job.get(fetch_with_args, 'testing'))
+        decorated_fetch_with_args = (
+            cacheback(fetch_on_miss=False)(fetch_with_args))
+        self.assertIsNone(decorated_fetch_with_args('testing'))
+        self.assertEqual(('testing',), decorated_fetch_with_args('testing'))
 
 
 class TestUsingConstructorArgs(TestCase):
@@ -31,3 +31,40 @@ class TestUsingConstructorArgs(TestCase):
     def test_passing_lifetime(self):
         job = FunctionJob(300)
         self.assertEqual(300, job.lifetime)
+
+
+class CustomFunctionJob(FunctionJob):
+    def __init__(self, custom_param=None, *args, **kwargs):
+        super(CustomFunctionJob, self).__init__(*args, **kwargs)
+        self.custom_param = custom_param
+
+    def fetch(self, *args, **kwargs):
+        item = super(CustomFunctionJob, self).fetch(*args, **kwargs)
+
+        return item, self.custom_param
+
+    def get_constructor_kwargs(self):
+        kwargs = super(CustomFunctionJob, self).get_constructor_kwargs()
+        kwargs['custom_param'] = self.custom_param
+
+        return kwargs
+
+
+class TestUsingCustomJobClass(TestCase):
+
+    def test_passing_job_class(self):
+        decorated_fetch = (cacheback(
+            fetch_on_miss=False,
+            job_class=CustomFunctionJob,
+            custom_param=200)(fetch))
+        self.assertIsNone(decorated_fetch())
+        self.assertEqual(((1, 2, 3), 200), decorated_fetch())
+
+    def test_passing_job_class_params(self):
+        self.assertRaisesMessage(
+            TypeError,
+            "__init__() got an unexpected keyword argument 'unknown_param'",
+            cacheback,
+            job_class=CustomFunctionJob,
+            custom_param=200,
+            unknown_param=100)


### PR DESCRIPTION
Helpful with custom FunctionJob/Job implementations. 

Currently to support any extra params of custom `job_class` by decorator a copy of `decorators.cacheback` decorator would have to be added. With this diff applied users can specify own `job_class` with any number of `job_class` params. 

@codeinthehole If needed happy to update docs as well

