### PR TITLE
Use an MD5 hash to generate cache keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ docs/_build
 dist/*
 .coverage
 TODO
+.tox

--- a/cacheback/base.py
+++ b/cacheback/base.py
@@ -4,12 +4,27 @@ import hashlib
 
 from django.core.cache import cache
 from django.conf import settings
+import six
 
 from cacheback import tasks
 
 logger = logging.getLogger('cacheback')
 
 MEMCACHE_MAX_EXPIRATION = 2592000
+
+
+def to_bytestring(value):
+    """
+    Encode a string as a UTF8 bytestring.  This function could be passed a
+    bytestring or unicode string so must distinguish between the two.
+    """
+    if isinstance(value, six.text_type):
+        return string.encode('utf8')
+    if isinstance(value, six.binary_type):
+        return value
+    if six.PY2:
+        return str(value)
+    return bytes(str(value), 'utf8')
 
 
 class Job(object):
@@ -313,7 +328,7 @@ class Job(object):
 
         This is for use in a cache key.
         """
-        return hashlib.md5(unicode(value)).hexdigest()
+        return hashlib.md5(to_bytestring(value)).hexdigest()
 
     def fetch(self, *args, **kwargs):
         """

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(name='django-cacheback',
           'django>=1.3,<1.7',
           'django-celery>=3.0',
           'celery<3.2',
+          'six',
           ],
       # See http://pypi.python.org/pypi?%3Aaction=list_classifiers
       classifiers=['Environment :: Web Environment',

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,3 +2,4 @@ django-nose==1.3
 nose==1.3.4
 pinocchio==0.4.2
 mock==1.0.1
+tox==1.8.1

--- a/tests/queryset_tests.py
+++ b/tests/queryset_tests.py
@@ -77,11 +77,3 @@ class TestEdgeCases(TestCase):
 
     def tearDown(self):
         cache.clear()
-
-    def test_unhashable_arg_raises_exception(self):
-        with self.assertRaises(RuntimeError):
-            self.job.get({})
-
-    def test_unhashable_kwarg_raises_exception(self):
-        with self.assertRaises(RuntimeError):
-            self.job.get(name={})

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,15 @@
+[tox]
+envlist=py27,py34,pypy
+
+[testenv]
+deps = -r{toxinidir}/test_requirements.txt
+commands = python runtests.py []
+
+[testenv:py27]
+basepython = python2.7
+
+[testenv:py34]
+basepython = python3.4
+
+[testenv:pypy]
+basepython = pypy


### PR DESCRIPTION
This is to address #28 where the builtin `hash` function produces difference cache keys in different processes on Python 3. 

Feedback welcome. 