### PR TITLE
Option added to use non-default cache alias

### DIFF
--- a/cacheback/base.py
+++ b/cacheback/base.py
@@ -1,7 +1,7 @@
 import time
 import logging
 
-from django.core.cache import caches, DEFAULT_CACHE_ALIAS
+from django.core.cache import get_cache, DEFAULT_CACHE_ALIAS
 from django.conf import settings
 
 from cacheback import tasks
@@ -52,7 +52,7 @@ class Job(object):
 
     def __init__(self):
         self.cache_alias = getattr(settings, 'CACHEBACK_CACHE_ALIAS', DEFAULT_CACHE_ALIAS)
-        self.cache = caches[self.cache_alias]
+        self.cache = get_cache(self.cache_alias)
 
     # --------
     # MAIN API

--- a/cacheback/function.py
+++ b/cacheback/function.py
@@ -9,6 +9,7 @@ class FunctionJob(Job):
     """
 
     def __init__(self, lifetime=None, fetch_on_miss=None, task_options=None):
+        super(FunctionJob, self).__init__()
         if lifetime is not None:
             self.lifetime = int(lifetime)
         if fetch_on_miss is not None:

--- a/cacheback/queryset.py
+++ b/cacheback/queryset.py
@@ -10,6 +10,7 @@ class QuerySetJob(Job):
         """
         :model: The model class to use
         """
+        super(QuerySetJob, self).__init__()
         self.model = model
         if lifetime is not None:
             self.lifetime = lifetime

--- a/tests/async_tests.py
+++ b/tests/async_tests.py
@@ -16,6 +16,7 @@ class StaleSyncJob(Job):
     fetch_on_stale_threshold = 10
 
     def __init__(self):
+        super(StaleSyncJob, self).__init__()
         self.called_async = False
 
     def fetch(self):


### PR DESCRIPTION
Fixes #32.

One can select the cache alias setting the `CACHEBACK_CACHE_ALIAS` option.