### PR TITLE
Add multiple Django versions tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,35 @@
 language: python
+python: 2.7
+sudo: false
 
-python:
-  - 2.7
-  - 3.3
-  - 3.4
-  - "pypy"
+env:
+    - TOX_ENV=py27-django15
+    - TOX_ENV=py27-django16
+    - TOX_ENV=py27-django17
+    - TOX_ENV=py27-django18
+    - TOX_ENV=py33-django15
+    - TOX_ENV=py33-django16
+    - TOX_ENV=py33-django17
+    - TOX_ENV=py33-django18
+    - TOX_ENV=py34-django15
+    - TOX_ENV=py34-django16
+    - TOX_ENV=py34-django17
+    - TOX_ENV=py34-django18
+    - TOX_ENV=pypy-django15
+    - TOX_ENV=pypy-django16
+    - TOX_ENV=pypy-django17
+    - TOX_ENV=pypy-django18
+    - TOX_ENV=py27-django14
 
 install:
-  - make test
+  - pip install tox
 
 script:
-  - ./runtests.py
+  - tox -e $TOX_ENV
+
+matrix:
+  allow_failures:
+    - env: TOX_ENV=py27-django18
+    - env: TOX_ENV=py33-django18
+    - env: TOX_ENV=py34-django18
+    - env: TOX_ENV=pypy-django18

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(name='django-cacheback',
       packages=find_packages(exclude=["sandbox*", "tests*"]),
       include_package_data=True,
       install_requires=[
-          'django>=1.3,<1.7',
+          'django>=1.3,<1.8',
           'django-celery>=3.0',
           'celery<3.2',
           'six',

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,12 @@
 [tox]
-envlist=py27,py34,pypy
+envlist=py{27,33,34,py}-django{15,16,17,18},py27-django14
 
 [testenv]
-deps = -r{toxinidir}/test_requirements.txt
+deps =
+    -r{toxinidir}/test_requirements.txt
+    django14: Django>=1.4,<1.5
+    django15: Django>=1.5,<1.6
+    django16: Django>=1.6,<1.7
+    django17: Django>=1.7,<1.8
+    django18: Django==1.8b1
 commands = python runtests.py []
-
-[testenv:py27]
-basepython = python2.7
-
-[testenv:py34]
-basepython = python3.4
-
-[testenv:pypy]
-basepython = pypy


### PR DESCRIPTION
I haven't tested django-cacheback in actual 1.7 project yet, but I guess it's ok remove restriction in setup.py since all tests are passing.

Hopefully, fixes #36