### PR TITLE
Verify cache success if backend is Memcache

### DIFF
--- a/cacheback/base.py
+++ b/cacheback/base.py
@@ -208,8 +208,8 @@ class Job(object):
         :data: The data to cache
         """
         self.cache.set(key, (expiry, data), self.cache_ttl)
-
-        if getattr(settings, 'CACHEBACK_VERIFY_CACHE_WRITE', True):
+        if getattr(settings, 'CACHEBACK_VERIFY_CACHE_WRITE', True) or \
+                'memcache' in self.cache.master_client.__class__.__name__.lower():
             # We verify that the item was cached correctly.  This is to avoid a
             # Memcache problem where some values aren't cached correctly
             # without warning.


### PR DESCRIPTION
When using a master+slave cache backend with asynchronous replication (i.e. Redis on Elasticache), it is common to hit the error "Unable to save data of type %s to cache". The write was performed on the master and the read may immediately go to the slave, which has not had time to receive the data.

I understand that setting `CACHEBACK_VERIFY_CACHE_WRITE` to False will prevent running into this false positive, however I'd like to suggest that data verification should only take place if you are using Memcache as your backend.. Thoughts?