### PR TITLE
Having issues getting tests to run out of the box.

### DIFF
--- a/makefile
+++ b/makefile
@@ -2,6 +2,7 @@
 
 install:
 	pip install -e .[tests]
+	pip install django_nose spec
 	pip install -r sandbox/requirements.txt
 
 release:

--- a/runtests.py
+++ b/runtests.py
@@ -30,7 +30,14 @@ if not settings.configured:
             ],
         BROKER_URL = 'django://',
         CELERY_ALWAYS_EAGER=True,
-        NOSE_ARGS=['-s', '--with-spec'],
+        NOSE_ARGS=['-s', '--with-specplugin'],
+        RQ_QUEUES = {
+            'default': {
+                'HOST': 'localhost',
+                'PORT': 6379,
+                'DB': 1,
+            }
+        },
     )
 
 from django_nose import NoseTestSuiteRunner


### PR DESCRIPTION
Hi, first of all I love the library. Thank you! It's the exact caching abstraction I'm looking for 99% of the time!

I'm looking to add a capability to bulk get cached keys—in the informal testing I've run, repeated calls to Django's `cache.get` don't even close to keep up with `cache.get_many`.

In working on that, I've had issues getting started contributing. Here's a pull request with a sketch of changes to get those issues addressed, along with a blow-by-blow of me trying set it up.

For reference, Mac OS and python version info:

    System Version: OS X 10.11.4 (15E65)
    Kernel Version: Darwin 15.4.0
    Python 2.7.11


**Issue 1 and 2: django_nose and spec missing**

```
<git clone and cd into django-cacheback>
$ mkvirtualenv django-cacheback
$ make
```

All good until I try to run tests.

```
$ ./runtests.py
Traceback (most recent call last):
  File "./runtests.py", line 36, in <module>
    from django_nose import NoseTestSuiteRunner
ImportError: No module named django_nose
```

No prob, `pip install django_nose`.

Next try:

```
$ ./runtests.py
nosetests tests -s --with-spec --verbosity=1
Usage: runtests.py [options]

runtests.py: error: no such option: --with-spec
```

No prob, `pip install spec`.

I've added both of these to the makefile, but where would they go best?


**Issue 3: nosetests spec flag**

Next try:

```
$ ./runtests.py
nosetests tests -s --with-spec --verbosity=1
Usage: runtests.py [options]

runtests.py: error: ambiguous option: --with-spec (--with-specplugin, --with-specselector?)
```

I presume this is a version issue, but I couldn't figure out if it was a change in `nose` or in `spec`. In any case, I just changed the NOSE_ARGS flag in runtests.py to use `--with-specplugin`. Maybe adding version pinning or a frozen requirements can prevent this for other people?


**Issue 4: RQ_QUEUES in settings**

Next try:

```
$ ./runtests.py 
nosetests tests -s --with-specplugin --verbosity=1
Creating test database for alias 'default'...

Unloadable or unexecutable test.

    A Failure case is placed in a test suite to indicate the presence of a
    test that could not be loaded or executed. A common example is a test
    module that fails to import.
- runTest
- runTest
- runTest
- runTest
- runTest
- runTest
- runTest
- runTest

======================================================================
ERROR: Failure: ImproperlyConfigured (You have to define RQ_QUEUES in settings.py)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/unittest/case.py", line 329, in run
    testMethod()
  File "/Users/agkish/.virtualenvs/django-cacheback/lib/python2.7/site-packages/nose/loader.py", line 418, in loadTestsFromName
    addr.filename, addr.module)
  File "/Users/agkish/.virtualenvs/django-cacheback/lib/python2.7/site-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/Users/agkish/.virtualenvs/django-cacheback/lib/python2.7/site-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/Users/agkish/django-cacheback/tests/async_tests.py", line 8, in <module>
    from cacheback.base import Job
  File "/Users/agkish/django-cacheback/cacheback/base.py", line 10, in <module>
    from cacheback.utils import enqueue_task, get_cache, get_job_class
  File "/Users/agkish/django-cacheback/cacheback/utils.py", line 19, in <module>
    from .rq_tasks import refresh_cache as rq_refresh_cache
  File "/Users/agkish/django-cacheback/cacheback/rq_tasks.py", line 4, in <module>
    @job
  File "/Users/agkish/.virtualenvs/django-cacheback/lib/python2.7/site-packages/django_rq/decorators.py", line 30, in job
    queue = get_queue(queue)
  File "/Users/agkish/.virtualenvs/django-cacheback/lib/python2.7/site-packages/django_rq/queues.py", line 109, in get_queue
    from .settings import QUEUES
  File "/Users/agkish/.virtualenvs/django-cacheback/lib/python2.7/site-packages/django_rq/settings.py", line 10, in <module>
    raise ImproperlyConfigured("You have to define RQ_QUEUES in settings.py")
ImproperlyConfigured: You have to define RQ_QUEUES in settings.py

... then a bunch more of these ...
```

For some reason, it appears that `tests/settings.py` isn't being used. I'm not sure why, but as a stopgap I've copied the RQ_QUEUES setting into `runtests.py`'s call to `settings.configure`.


**Issue 5: py.test fixtures aren't working**

I turned on a redis server in the background as well. Next try:

```
$ ./runtests.py
nosetests tests -s --with-specplugin --verbosity=1
Creating test database for alias 'default'...

Job with stale sync refresh attribute set
- hits cache within cache lifetime
- triggers async refresh after lifetime but before stale threshold
- triggers sync refresh after stale threshold

... lots more tests run ...

Get job class
- class
- invalid class
- invalid module

======================================================================
ERROR: tests.test_base_job.TestJob.test_async_refresh
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/unittest/case.py", line 329, in run
    testMethod()
  File "/Users/agkish/.virtualenvs/django-cacheback/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
TypeError: test_async_refresh() takes exactly 2 arguments (1 given)

======================================================================
ERROR: tests.test_base_job.TestJob.test_get_hit
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/unittest/case.py", line 329, in run
    testMethod()
  File "/Users/agkish/.virtualenvs/django-cacheback/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
TypeError: test_get_hit() takes exactly 2 arguments (1 given)

======================================================================
ERROR: tests.test_base_job.TestJob.test_get_miss_empty_async
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/Cellar/python/2.7.11/Frameworks/Python.framework/Versions/2.7/lib/python2.7/unittest/case.py", line 329, in run
    testMethod()
  File "/Users/agkish/.virtualenvs/django-cacheback/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
TypeError: test_get_miss_empty_async() takes exactly 2 arguments (1 given)

... bunch more like this ...
```

The issue appears to be that the py.test fixtures, `rq_worker` for example, aren't passed to the nose test cases. In fact, it appears that none of the fixtures are being called at all. For example, the `cleared_cache` fixture is set up in couple of places like this:

```python
@pytest.mark.usefixtures('cleared_cache', scope='function')
class TestJob:
    ...
```

To test whether it was working, I modified it just create a text file to indicate that it'd been called (so I didn't have to worry about nose eating stdout):

```
@pytest.fixture()
def cleared_cache(request):
    with file('~/django-cacheback/sentinel.txt', 'w') as f:
        f.write('cleared_cache called')
    cache.clear()
```

`sentinel.txt` never got created. At this point I got totally stumped. Ideas?


Thanks!




