### PR TITLE
Issue 57

### DIFF
--- a/cacheback/base.py
+++ b/cacheback/base.py
@@ -5,6 +5,7 @@ import time
 
 from django.conf import settings
 from django.core.cache import DEFAULT_CACHE_ALIAS
+from django.db.models import Model as DjangoModel
 from django.utils import six
 
 from cacheback.utils import enqueue_task, get_cache, get_job_class
@@ -21,9 +22,14 @@ Call = collections.namedtuple("Call", ['args', 'kwargs'])
 
 def to_bytestring(value):
     """
-    Encode a string as a UTF8 bytestring.  This function could be passed a
-    bytestring or unicode string so must distinguish between the two.
+    Encode an object as a UTF8 bytestring.  This function could be passed a
+    bytestring, unicode string or object so must distinguish between them.
+
+    :param value: object we want to transform into a bytestring
+    :returns: a bytestring
     """
+    if isinstance(value, DjangoModel):
+        return ('%s:%s' % (value.__class__, hash(value))).encode('utf-8')
     if isinstance(value, six.text_type):
         return value.encode('utf8')
     if isinstance(value, six.binary_type):

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -17,7 +17,6 @@ def decorated_dummy_function(param):
 
 @pytest.mark.usefixtures('cleared_cache', scope='function')
 class TestFunctionJob:
-
     def test_init_defaults(self):
         job = FunctionJob()
         assert job.lifetime == 600
@@ -52,7 +51,6 @@ class TestFunctionJob:
 
 @pytest.mark.django_db
 class TestQuerySetJob:
-
     def test_init_defaults(self):
         job = QuerySetJob(DummyModel)
         assert job.lifetime == 600
@@ -78,8 +76,17 @@ class TestQuerySetJob:
 
 
 @pytest.mark.django_db
-class TestQuerySetGetJob:
+class TestDjangoModelJobKey:
+    def test_key_django_model(self):
+        alan = DummyModel.objects.create(name="Alan")
+        john = DummyModel.objects.create(name="John")
+        assert FunctionJob().key(alan) == \
+            'cacheback.function.FunctionJob:9df82067f944cc95795bc89ec0aa65df'
+        assert FunctionJob().key(alan) != FunctionJob().key(john)
 
+
+@pytest.mark.django_db
+class TestQuerySetGetJob:
     def test_fetch(self):
         dummy1 = DummyModel.objects.create(name='Foo')
         assert QuerySetGetJob(DummyModel).fetch(name='Foo') == dummy1
@@ -87,7 +94,6 @@ class TestQuerySetGetJob:
 
 @pytest.mark.django_db
 class TestQuerySetGetFilterJob:
-
     def test_fetch(self):
         dummy1 = DummyModel.objects.create(name='Foo')
         dummy2 = DummyModel.objects.create(name='Bar')


### PR DESCRIPTION
Fixes issue #57 where trying to make a cache key from a Django Model instance results in that model's being `str()` instead of `hash()`