### PR TITLE
Adding 'set' method to Job class

### DIFF
--- a/cacheback/base.py
+++ b/cacheback/base.py
@@ -93,8 +93,8 @@ class Job(six.with_metaclass(JobBase)):
 
     #: parameter name to pass in the data which is to be cached in the set method. Data can
     #: also be passed as last positional argument in set method, but using a kw arg may be
-    #: clearer or even necessary. Defaults to 'cache_payload'
-    cache_payload_label = 'cache_payload'
+    #: clearer or even necessary. Defaults to 'data'
+    set_data_kwarg = 'data'
 
     #: Overrides options for `refresh_cache.apply_async` (e.g. `queue`).
     task_options = None
@@ -237,9 +237,9 @@ class Job(six.with_metaclass(JobBase)):
             self.cache.delete(key)
 
     def set(self, *raw_args, **raw_kwargs):
-        if raw_kwargs.get(self.cache_payload_label):
-            data = raw_kwargs[self.cache_payload_label]
-            del raw_kwargs[self.cache_payload_label]
+        if raw_kwargs.get(self.set_data_kwarg):
+            data = raw_kwargs[self.set_data_kwarg]
+            del raw_kwargs[self.set_data_kwarg]
         else:
             raw_args = list(raw_args)
             data = raw_args.pop()

--- a/cacheback/jobs.py
+++ b/cacheback/jobs.py
@@ -12,7 +12,7 @@ class FunctionJob(Job):
     """
 
     def __init__(self, lifetime=None, fetch_on_miss=None, cache_alias=None,
-                 task_options=None):
+                 task_options=None, cache_payload_label=None):
         super(FunctionJob, self).__init__()
         if lifetime is not None:
             self.lifetime = int(lifetime)
@@ -22,6 +22,8 @@ class FunctionJob(Job):
             self.cache_alias = cache_alias
         if task_options is not None:
             self.task_options = task_options
+        if cache_payload_label is not None:
+            self.cache_payload_label = cache_payload_label
 
     def get_init_kwargs(self):
         """

--- a/cacheback/jobs.py
+++ b/cacheback/jobs.py
@@ -12,7 +12,7 @@ class FunctionJob(Job):
     """
 
     def __init__(self, lifetime=None, fetch_on_miss=None, cache_alias=None,
-                 task_options=None, cache_payload_label=None):
+                 task_options=None, set_data_kwarg=None):
         super(FunctionJob, self).__init__()
         if lifetime is not None:
             self.lifetime = int(lifetime)
@@ -22,8 +22,8 @@ class FunctionJob(Job):
             self.cache_alias = cache_alias
         if task_options is not None:
             self.task_options = task_options
-        if cache_payload_label is not None:
-            self.cache_payload_label = cache_payload_label
+        if set_data_kwarg is not None:
+            self.set_data_kwarg = set_data_kwarg
 
     def get_init_kwargs(self):
         """

--- a/tests/test_base_job.py
+++ b/tests/test_base_job.py
@@ -34,7 +34,7 @@ class FailJob(Job):
 
 
 class CustomPayloadLabelJob(Job):
-    cache_payload_label = 'my_cache_data'
+    set_data_kwarg = 'my_cache_data'
 
 
 @pytest.mark.usefixtures('cleared_cache', scope='function')
@@ -239,7 +239,7 @@ class TestJob:
     def test_set_default_kw_arg(self):
 
         job = DummyJob()
-        job.set('foo', cache_payload='MANUALLY_SET_WITH_KW_ARG')
+        job.set('foo', data='MANUALLY_SET_WITH_KW_ARG')
 
         assert job.get('foo') == 'MANUALLY_SET_WITH_KW_ARG'
 

--- a/tests/test_base_job.py
+++ b/tests/test_base_job.py
@@ -33,6 +33,10 @@ class FailJob(Job):
         raise Exception('JOB-FAILED')
 
 
+class CustomPayloadLabelJob(Job):
+    cache_payload_label = 'my_cache_data'
+
+
 @pytest.mark.usefixtures('cleared_cache', scope='function')
 class TestJob:
 
@@ -215,6 +219,36 @@ class TestJob:
             'tests.test_base_job.DummyJob:def474a313bffa002eae8941b2e12620:'
             '8856328b99ee7881e9bf7205296e056d:c9ebc77141c29f6d619cf8498631343d'
         )
+
+    def test_set(self):
+        job = DummyJob()
+        job.set('foo', 'MANUALLY_SET')
+        assert job.get('foo') == 'MANUALLY_SET'
+
+    def test_set_preset_cache(self):
+        job = DummyJob()
+        assert job.get('foo')[0] == 'JOB-EXECUTED:foo'
+
+        # It is cached
+        assert job.key('foo') in job.cache
+
+        job.set('foo', 'MANUALLY_SET')
+
+        assert job.get('foo') == 'MANUALLY_SET'
+
+    def test_set_default_kw_arg(self):
+
+        job = DummyJob()
+        job.set('foo', cache_payload='MANUALLY_SET_WITH_KW_ARG')
+
+        assert job.get('foo') == 'MANUALLY_SET_WITH_KW_ARG'
+
+    def test_set_default_custom_kw_arg(self):
+
+        job = CustomPayloadLabelJob()
+        job.set('foo', my_cache_data='MANUALLY_SET_WITH_CUSTOM_KW_ARG')
+
+        assert job.get('foo') == 'MANUALLY_SET_WITH_CUSTOM_KW_ARG'
 
     @pytest.mark.django_db
     def test_key_django_model(self):

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -23,6 +23,11 @@ def fetch_cache_alias_function(param):
     return 'JOB-EXECUTED:{0}'.format(param)
 
 
+@cacheback(cache_payload_label='my_data')
+def custom_payload_label_function(param):
+    return 'JOB-EXECUTED:{0}'.format(param)
+
+
 @pytest.mark.usefixtures('cleared_cache', scope='function')
 class TestCachebackDecorator:
 
@@ -46,6 +51,24 @@ class TestCachebackDecorator:
 
     def test_cache_alias(self):
         assert fetch_cache_alias_function('foo') == 'JOB-EXECUTED:foo'
+
+    def test_set(self):
+        no_fetch_miss_function.job.set(
+            no_fetch_miss_function, 'foo', 'MANUALLY_SET')
+
+        assert no_fetch_miss_function('foo') == 'MANUALLY_SET'
+
+    def test_set_kwarg(self):
+        no_fetch_miss_function.job.set(
+            no_fetch_miss_function, 'foo', cache_payload='MANUALLY_SET_WITH_KWARG')
+
+        assert no_fetch_miss_function('foo') == 'MANUALLY_SET_WITH_KWARG'
+
+    def test_set_custom_kwarg(self):
+        custom_payload_label_function.job.set(
+            custom_payload_label_function, 'foo', my_data='MANUALLY_SET_WITH_CUSTOM_KWARG')
+
+        assert custom_payload_label_function('foo') == 'MANUALLY_SET_WITH_CUSTOM_KWARG'
 
     @pytest.mark.redis_required
     def test_hit(self, rq_burst):

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -23,7 +23,7 @@ def fetch_cache_alias_function(param):
     return 'JOB-EXECUTED:{0}'.format(param)
 
 
-@cacheback(cache_payload_label='my_data')
+@cacheback(set_data_kwarg='my_data')
 def custom_payload_label_function(param):
     return 'JOB-EXECUTED:{0}'.format(param)
 
@@ -60,7 +60,7 @@ class TestCachebackDecorator:
 
     def test_set_kwarg(self):
         no_fetch_miss_function.job.set(
-            no_fetch_miss_function, 'foo', cache_payload='MANUALLY_SET_WITH_KWARG')
+            no_fetch_miss_function, 'foo', data='MANUALLY_SET_WITH_KWARG')
 
         assert no_fetch_miss_function('foo') == 'MANUALLY_SET_WITH_KWARG'
 


### PR DESCRIPTION
Hi there,

I work for O'Reilly Media, and we use Cacheback a lot in the systems that support Safari Books Online. First off, thanks very much for maintaining Cacheback — it's a really great module, and helps us give our users a smooth, fast service.

I recently came across a case where I wanted to be able to set the data cached for a cacheback function manually. Basically we have some records in a microservice which can be pulled in a list, and pulled individually and which we also cache — it made sense to be able to update the individually cached records from the list records when we can (and thus help maintain data integrity). There are other ways we could have achieved that (using nested caches, for example) but it seemed reasonable and clearest to add a set method directly. I did that in a subclass for our immediate needs, but I hope this functionality will be accepted into the core Cacheback distribution.

Obviously I realised that there is a `store` method which can be used, but that has different semantics from the `get` and `delete` methods, and to use that in code would mean we'd also have to call `prepare_args` etc., which felt a little more fragile to me.

I think adding a `set` method makes it easier to perform richer cache management, particularly useful when using microservices extensively, and also when doing fragment caching. It essentially changes nothing else in Cacheback (apart from an additional variable in the `FunctionJob` `init` method) so hopefully wouldn't be too controversial.

I've provided a few ways to pass in the data to be cached — you can just put it as the last positional argument (what we use). But if your function to cache uses named args as well, that may be confusing, so we also check for a `cache_payload` named argument. That introduces the slight risk that your function already uses a `cache_payload` named argument, so that name can be overridden using the `cache_payload_label` class variable. If you don't want to use the `set` method, all of those things can be safely complete ignored.

I've also added tests for the set method, used directly and also on a decorated function.

Thanks very much! Yours, Stephen Betts.