### PR TITLE
Bumping version number and changelog.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+1.3
+~~~
+* Add set method, with the same semantics as delete & get. Updated docs.
+
 1.2
 ~~~
 
@@ -30,7 +34,7 @@ Changelog
 
 0.9
 ~~~
-* Add support for other caches (`#32`_) 
+* Add support for other caches (`#32`_)
 * Fix inconsistent hasing issue in Python 3.x (`#28`_)
 * Allow ``job_class_kwargs`` to be passed to ``cacheback`` decorator (`#31`_)
 

--- a/cacheback/__init__.py
+++ b/cacheback/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '1.2'
+__version__ = '1.3'
 
 default_app_config = 'cacheback.apps.CachebackConfig'


### PR DESCRIPTION
Hi there,

I realised that without bumping the version number the new `set` method wouldn't be available through pip (should have thought of that before but it slipped my mind). I guess you will still have to create the egg and upload it — for which I'd be very grateful :-)

Thanks very much,

Stephen.