### PR TITLE
Add CACHEBACK_CELERY_IGNORE_RESULT setting

### DIFF
--- a/cacheback/tasks.py
+++ b/cacheback/tasks.py
@@ -1,7 +1,11 @@
 from celery import shared_task
+from django.conf import settings
 
 
-@shared_task
+ignore_result = getattr(settings, 'CACHEBACK_CELERY_IGNORE_RESULT', False)
+
+
+@shared_task(ignore_result=ignore_result)
 def refresh_cache(klass_str, obj_args, obj_kwargs, call_args, call_kwargs):
     from .base import Job
     Job.perform_async_refresh(klass_str, obj_args, obj_kwargs, call_args, call_kwargs)

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -21,3 +21,10 @@ This verifies the data is correctly written to memcache. If not, then a
 
 This defines the task queue to use. Valid options are ``rq`` and ``celery``.
 Make sure that the corresponding task queue is configured too.
+
+
+``CACHEBACK_CELERY_IGNORE_RESULT``
+------------------------
+
+This specifies whether to ignore the result of the ``refresh_cache`` task
+and prevent Celery from storing it into its results backend.


### PR DESCRIPTION
Give users the option to ignore `refresh_cache`'s result (and avoid what's in the screenshot):

<img width="949" alt="Screen Shot 2020-07-02 at 1 47 45 AM" src="https://user-images.githubusercontent.com/1369747/86302504-3483c580-bc09-11ea-9a8b-83d6b2ea8fbd.png">

Also any ideas on how to test this, since the flag is set at compile time? I used this in a project and it's definitely working but it would be nice to add an automated test.