### PR TITLE
Optionally pass generated key over to async_refresh

### DIFF
--- a/cacheback/rq_tasks.py
+++ b/cacheback/rq_tasks.py
@@ -2,7 +2,7 @@ from django_rq import job
 
 
 @job
-def refresh_cache(klass_str, obj_args, obj_kwargs, call_args, call_kwargs):
+def refresh_cache(klass_str, obj_args, obj_kwargs, call_args, call_kwargs, key=None):
     from .base import Job
 
-    Job.perform_async_refresh(klass_str, obj_args, obj_kwargs, call_args, call_kwargs)
+    Job.perform_async_refresh(klass_str, obj_args, obj_kwargs, call_args, call_kwargs, key=key)

--- a/cacheback/tasks.py
+++ b/cacheback/tasks.py
@@ -3,7 +3,7 @@ from django.conf import settings
 
 
 @shared_task(ignore_result=getattr(settings, 'CACHEBACK_TASK_IGNORE_RESULT', False))
-def refresh_cache(klass_str, obj_args, obj_kwargs, call_args, call_kwargs):
+def refresh_cache(klass_str, obj_args, obj_kwargs, call_args, call_kwargs, key=None):
     from .base import Job
 
-    Job.perform_async_refresh(klass_str, obj_args, obj_kwargs, call_args, call_kwargs)
+    Job.perform_async_refresh(klass_str, obj_args, obj_kwargs, call_args, call_kwargs, key=key)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,5 @@
+# This will make sure the app is always imported when
+# Django starts so that shared_task will use this app.
+from .celery import app as celery_app
+
+__all__ = ('celery_app',)

--- a/tests/celery.py
+++ b/tests/celery.py
@@ -1,0 +1,22 @@
+import os
+
+from celery import Celery
+
+# Set the default Django settings module for the 'celery' program.
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'tests.settings')
+
+app = Celery('proj')
+
+# Using a string here means the worker doesn't have to serialize
+# the configuration object to child processes.
+# - namespace='CELERY' means all celery-related configuration keys
+#   should have a `CELERY_` prefix.
+app.config_from_object('django.conf:settings', namespace='CELERY')
+
+# Load task modules from all registered Django apps.
+app.autodiscover_tasks()
+
+
+@app.task(bind=True)
+def debug_task(self):
+    print(f'Request: {self.request!r}')

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -66,8 +66,7 @@ class TestFunctionJob:
             'cache_alias': 'secondary',
         }
 
-    @pytest.mark.skipif(celery.VERSION[:2] < (4, 4), reason="will only work with the new kombu serializer")
-    def test_non_serializable_creates_two_entries(self, settings):
+    def test_non_serializable_creates_one_entry(self, settings):
         settings.CELERY_TASK_ALWAYS_EAGER = True
         settings.CACHEBACK_TASK_QUEUE = "celery"
 
@@ -85,10 +84,12 @@ class TestFunctionJob:
 
         assert empty_result is None
         assert dec_function.job.cache.has_key(sync_key)
-        assert dec_function.job.cache.has_key(async_key)
+        assert not dec_function.job.cache.has_key(async_key)
 
         result = dec_function(arg)
 
+        # use str_arg for dummy_function as celery serializes the UUID as a str
+        assert result == dummy_function(str_arg)
 
 @pytest.mark.django_db
 class TestQuerySetJob:


### PR DESCRIPTION
The main reason for this is supporting the new Celery/Kombu serializer
where `UUID`s don't raise anymore but are instead parsed as `str`s. This
change will generate two cache entries for jobs that iterables where
`UUID`s get traversed as part of `Job.hash` due to the generated keys
being different in `django-cacheback` sync code and the async task (as
it will now receive a `str` instead of an `UUID`). The only key that
`django-cacheback` will be able to read is the first one and thus there
will always be a cache miss, a task executed and, seemingly, no return
value.

Link to the Kombu commit:
https://github.com/celery/kombu/commit/55452a15469cff38ad9a49e2730fe7250ec56ccd
Link to the Celery commit
:https://github.com/celery/celery/commit/6a9a540c37ec43257d587d8f1e9bea21ed588191

This will affect all versions of celery after 4.4.x when `fetch_on_miss`
is set to `False`.

The most simple example I can come up with at the time is:

```python
import uuid
from cacheback.decorators import cacheback

def example_fn(some_uuid: uuid.UUID):
    return "some-string"

def test_non_serializable_input_breaks():
    fn = cacheback(fetch_on_miss=False)(example_fn)
    args = [[uuid.uuid4()]]

    result = fn(*args)

    assert len(fn.job.cache._cache) == 2

    fn(*args)

    assert len(fn.job.cache._cache) == 2
```

I could try setting up an application that uses Celery to make my point
clearer if that's required c:.

The reason I did not write any tests is that none of the existing ones
use celery (it is, after all, an optional requirement) and I didn't know how
to approach writing one. I'm open to suggestions.

Just for completeness sake, my initial approach made many tests fail
because I was using `, key` instead of `, key=None` in the RQ 
`refresh_cache` declaration.